### PR TITLE
Make chat text selectable + Restore text format

### DIFF
--- a/app/scripts/components/message.jsx
+++ b/app/scripts/components/message.jsx
@@ -55,6 +55,7 @@ export default class Message extends React.Component {
         return (
             <li className='message'>
                 <Timestamp timestamp={message.timestamp} />
+                <span className='message-separator'>&nbsp;</span>
                 <span className='message-contents'>
                     <MessageHandler message={message} />
                 </span>

--- a/app/scripts/components/messages/action.jsx
+++ b/app/scripts/components/messages/action.jsx
@@ -7,7 +7,7 @@ export default class Action extends React.Component {
 
         return (
             <span className='action'>
-                <Nick nick={message.from} />&nbsp;
+                •&nbsp;<Nick nick={message.from} />&nbsp;
                 {message.msg}
             </span>
         );

--- a/app/scripts/components/messages/error.jsx
+++ b/app/scripts/components/messages/error.jsx
@@ -6,7 +6,7 @@ export default class Error extends React.Component {
 
         return (
             <span className='message-error'>
-                {message.params.join(' ')}
+                Error: {message.params.join(' ')}
             </span>
         );
     }

--- a/app/scripts/components/messages/invite.jsx
+++ b/app/scripts/components/messages/invite.jsx
@@ -7,7 +7,7 @@ export default class Invite extends React.Component {
 
         return (
             <span className='invite'>
-                <Nick nick={message.from} /> has invited you to join {message.chan}
+                &raquo;&nbsp;<Nick nick={message.from} /> has invited you to join {message.chan}
             </span>
         );
     }

--- a/app/scripts/components/messages/join.jsx
+++ b/app/scripts/components/messages/join.jsx
@@ -7,8 +7,8 @@ export default class Join extends React.Component {
 
         return (
             <span className='join'>
-                →&nbsp;<Nick nick={message.nick} />&nbsp;
-                has joined {message.chan}
+                →&nbsp;<Nick nick={message.nick} />
+                &nbsp;has joined {message.chan}
             </span>
         );
     }

--- a/app/scripts/components/messages/join.jsx
+++ b/app/scripts/components/messages/join.jsx
@@ -7,7 +7,7 @@ export default class Join extends React.Component {
 
         return (
             <span className='join'>
-                <Nick nick={message.nick} />&nbsp;
+                →&nbsp;<Nick nick={message.nick} />&nbsp;
                 has joined {message.chan}
             </span>
         );

--- a/app/scripts/components/messages/motd.jsx
+++ b/app/scripts/components/messages/motd.jsx
@@ -5,7 +5,7 @@ export default class Motd extends React.Component {
         const message = this.props.message;
 
         return (
-            <span className='motd'><pre class-name='motd-text'>{message.motd}</pre></span>
+            <span className='motd'>MOTD: <pre class-name='motd-text'>{message.motd}</pre></span>
         );
     }
 }

--- a/app/scripts/components/messages/msg.jsx
+++ b/app/scripts/components/messages/msg.jsx
@@ -6,7 +6,7 @@ export default class Msg extends React.Component {
         const message = this.props.message;
         return (
             <span className='msg'>
-                &lt;<Nick nick={message.from} />&gt;&nbsp;
+                <Nick nick={message.from} appendText=':'/>&nbsp;
                 {message.msg}
             </span>
         );

--- a/app/scripts/components/messages/msg.jsx
+++ b/app/scripts/components/messages/msg.jsx
@@ -6,7 +6,7 @@ export default class Msg extends React.Component {
         const message = this.props.message;
         return (
             <span className='msg'>
-                <Nick nick={message.from} />&nbsp;
+                &lt;<Nick nick={message.from} />&gt;&nbsp;
                 {message.msg}
             </span>
         );

--- a/app/scripts/components/messages/notice.jsx
+++ b/app/scripts/components/messages/notice.jsx
@@ -7,7 +7,7 @@ export default class Notice extends React.Component {
 
         return (
             <span className='notice'>
-                <Nick nick={message.from} />&nbsp;
+                &raquo;&nbsp;&lt;<Nick nick={message.from} />&gt;&nbsp;
                 {message.msg}
             </span>
         );

--- a/app/scripts/components/messages/notice.jsx
+++ b/app/scripts/components/messages/notice.jsx
@@ -7,7 +7,7 @@ export default class Notice extends React.Component {
 
         return (
             <span className='notice'>
-                &raquo;&nbsp;&lt;<Nick nick={message.from} />&gt;&nbsp;
+                &raquo;&nbsp;<Nick nick={message.from} appendText=':' />&nbsp;
                 {message.msg}
             </span>
         );

--- a/app/scripts/components/messages/part.jsx
+++ b/app/scripts/components/messages/part.jsx
@@ -7,7 +7,7 @@ export default class Part extends React.Component {
 
         return (
             <span className='part'>
-                <Nick nick={message.nick} />&nbsp;
+                ←&nbsp;<Nick nick={message.nick} />&nbsp;
                 has left {message.chan}&nbsp;{message.reason ? '(' + message.reason + ')' : ''}
             </span>
         );

--- a/app/scripts/components/messages/quit.jsx
+++ b/app/scripts/components/messages/quit.jsx
@@ -7,7 +7,7 @@ export default class Quit extends React.Component {
 
         return (
             <span className='quit'>
-                <Nick nick={message.nick} />&nbsp;
+                ←&nbsp;<Nick nick={message.nick} />&nbsp;
                 has quit&nbsp;{message.reason ? '(' + message.reason + ')' : ''}
             </span>
         );

--- a/app/scripts/components/messages/timestamp.jsx
+++ b/app/scripts/components/messages/timestamp.jsx
@@ -11,8 +11,8 @@ export default class Timestamp extends React.Component {
 
     render() {
         const timestamp = moment(this.props.timestamp).format(TIMESTAMP_FORMAT);
-
-        return <span className='timestamp'>{timestamp}</span>;
+        
+        return <span className='timestamp'>[{timestamp}]</span>;
     }
 }
 

--- a/app/scripts/components/messages/topic.jsx
+++ b/app/scripts/components/messages/topic.jsx
@@ -8,7 +8,7 @@ export default class Topic extends React.Component {
         if(message.topic) {
             return (
                 <span className='topic'>
-                    <span className='topic-text'>{message.topic}</span>
+                    Topic is <span className='topic-text'>{message.topic}</span>
                 </span>
             );
         }

--- a/app/scripts/components/nick.jsx
+++ b/app/scripts/components/nick.jsx
@@ -4,18 +4,22 @@ import hash from 'squelch-nick-hash';
 
 export default class Nick extends React.Component {
     render() {
-        const nick = this.props.nick;
+        const { nick, appendText, prependText } = this.props;
         const className = classnames({
             [this.props.className]: true,
             nick: true,
             ['nick-color-' + hash(nick)]: true
         });
 
-        return <span className={className}>{nick}</span>;
+        const text = (prependText || '')  + nick + (appendText || '');
+
+        return <span className={className}>{text}</span>;
     }
 }
 
 Nick.propTypes = {
     nick: React.PropTypes.string.isRequired,
-    className: React.PropTypes.string
+    className: React.PropTypes.string,
+    appendText: React.PropTypes.string,
+    prependText: React.PropTypes.string
 };


### PR DESCRIPTION
Turns out you can't select text that is set via CSS, so we'll need a better way of changing the text format. 

Changed msgs to use nick: instead of <nick>.

Resolves #40 
